### PR TITLE
add a couple more columns to the output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# vscode files
+.vscode
+
+# eclipse files
+.cproject
+.project
+.classpath
+.settings
+
+*.o
+
+# perf output
+perf.data*
+
+# maven output
+target
+
+consoleversion/generated.cpp
+consoleversion/testingmlp

--- a/consoleversion/common.hpp
+++ b/consoleversion/common.hpp
@@ -13,3 +13,7 @@ constexpr int NAKED_MAX = 100;
 constexpr int DO_NAKED = true;
 
 void naked_measure_body(float (&time_measure)[NAKED_MAX], uint64_t *bigarray, size_t howmanyhits, size_t repeat);
+
+typedef uint64_t (access_method_f)(uint64_t *bigarray, size_t howmanyhits);
+
+float time_one(uint64_t *bigarray, size_t howmanyhits, size_t repeat, access_method_f *method, size_t lanes, float firsttime, float lasttime);

--- a/consoleversion/gen.py
+++ b/consoleversion/gen.py
@@ -5,46 +5,22 @@ print("#include \"common.hpp\"\n#include \"math.h\"\n")
 for i in range(1,100):
     print("uint64_t naked_access_%d(uint64_t *bigarray, size_t howmanyhits) {"%(i))
     for j in range(1,i+1):
-        print("uint64_t val%d = %d;" %(j,j))
-    print ("size_t howmanyhits_perlane = howmanyhits / %d;"%(i))
-    print("for (size_t counter = 0; counter < howmanyhits_perlane; counter++) {")
+        print("  uint64_t val%d = %d;" %(j,j))
+    print ("  size_t howmanyhits_perlane = howmanyhits / %d;"%(i))
+    print("  for (size_t counter = 0; counter < howmanyhits_perlane; counter++) {")
     for j in range(1,i+1):
-        print("val%d = bigarray[val%d];" %(j,j))
-    print("}")
-    ret = "val1 "
+        print("    val%d = bigarray[val%d];" %(j,j))
+    print("  }")
+    ret = "  val1 "
     for  j in range(2,i+1):
       ret += "+ val%d " %(j)
-    print("return ", ret,";")
+    print("  return ", ret,";")
     print("}")
-    print("""
-
-float time_me%d(uint64_t *bigarray, size_t howmanyhits,
-              size_t repeat) {
-  clock_t begin_time, end_time;
-  float mintime = 99999999999;
-  uint64_t bogus = 0;
-  while (repeat-- > 0) {
-    begin_time = clock();
-    bogus += naked_access_%d(bigarray, howmanyhits);
-    end_time = clock();
-    float tv = float(end_time - begin_time) / CLOCKS_PER_SEC;
-    if (tv < mintime)
-      mintime = tv;
-  }
-  if (bogus == 0x010101) {
-    printf("ping!");
-  }
-  // compute the bandwidth 
-  size_t cachelineinbytes = 64;
-  size_t volume = ( howmanyhits / %d * %d ) * cachelineinbytes ;  
-  double mbpers = volume / mintime / (1024.0 * 1024.);
-  double nanoperquery = 1000 * 1000 *  1000 * mintime / ( howmanyhits / %d * %d );
-  printf("%%12d %%12f %%12.0f     %%12.1f \\n", %d, mintime, round(mbpers), round(nanoperquery));
-  return mintime;
-}
-"""%(i,i,i,i,i,i,i))
 
 
 print("void naked_measure_body(float (&time_measure)[NAKED_MAX], uint64_t *bigarray, size_t howmanyhits, size_t repeat) {")
-for i in range(1, 100):  print("  time_measure[%d] = time_me%d(bigarray, howmanyhits, repeat);"%(i,i))
+for i in range(1, 100):
+    first = "0.0" if i == 1 else "time_measure[1]"
+    last  = "0.0" if i == 1 else "time_measure[%d]"%(i-1)
+    print("  time_measure[%d] = time_one(bigarray, howmanyhits, repeat, naked_access_%d, %d, %s, %s);"%(i,i,i,first,last))
 print("}")


### PR DESCRIPTION
This adds two more columns to the output which are handy at a glance to see what is going on. The output looks like:

```
Legend:
  BandW: Implied bandwidth (assuming 64-byte cache line) in MB/s
  % Eff: Effectiness of this lane count compared to the prior, as a % of ideal
  Speedup: Speedup factor for this many lanes versus one lane
---------------------------------------------------------------------
- # of lanes --- time (s) ---- BandW -- ns/hit -- % Eff -- Speedup --
---------------------------------------------------------------------
           1     2.526743        811      75.3       0%        1.0
           2     1.249762       1639      37.2     101%        2.0
           3     0.828584       2472      24.7     101%        3.0
           4     0.621303       3296      18.5     100%        4.1
           5     0.501651       4083      15.0      96%        5.0
           6     0.420514       4870      12.5      97%        6.0
           7     0.366115       5594      10.9      91%        6.9
           8     0.322970       6341       9.6      94%        7.8
           9     0.291011       7038       8.7      89%        8.7
          10     0.266098       7696       7.9      86%        9.5
          11     0.250804       8166       7.5      63%       10.1
          12     0.245783       8333       7.3      24%       10.3
          13     0.244604       8373       7.3       6%       10.3
          14     0.245645       8337       7.3      -6%       10.3
          15     0.245139       8354       7.3       3%       10.3
          16     0.245239       8351       7.3      -1%       10.3
          17     0.245368       8347       7.3      -1%       10.3
          18     0.245179       8353       7.3       1%       10.3
          19     0.245166       8354       7.3       0%       10.3
          20     0.245274       8350       7.3      -1%       10.3
          21     0.245278       8350       7.3      -0%       10.3
          22     0.245216       8352       7.3       1%       10.3
          23     0.245356       8347       7.3      -1%       10.3
          24     0.245660       8337       7.3      -3%       10.3
          25     0.245698       8335       7.3      -0%       10.3
          26     0.245824       8331       7.3      -1%       10.3
```

The columns are the % Eff which is how much adding this lane helped, compared to the "ideal" (i.e., going from 2 to 3 lanes ideally increases throughput by 50%, if it only increased by 40%, efficiency would be "80%" for that lane.

The last column just shows the speedup versus the lane 1 case.

I also refactored a bit the generation, moving the `time_me` method which we really only need one copy of out to the non-generated file.
