### PR TITLE
Misc changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,7 @@ perf.data*
 # maven output
 target
 
+/*/results
+
 consoleversion/generated.cpp
 consoleversion/testingmlp

--- a/consoleversion/Makefile
+++ b/consoleversion/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS = -O3 -std=c++11 -Wall 
+CXXFLAGS = -O3 -std=c++11 -Wall -g
 
 .PHONY = clean test
 
@@ -13,8 +13,8 @@ generated.cpp : gen.py
 	python3 gen.py > generated.cpp
 endif
 
-%.o : %.cpp
-	$(CXX) $(CXXFLAGS) -c $^
+%.o : %.cpp common.hpp
+	$(CXX) $(CXXFLAGS) -c $<
 
 test: testingmlp
 	./testingmlp

--- a/consoleversion/Makefile
+++ b/consoleversion/Makefile
@@ -1,12 +1,12 @@
 CXXFLAGS = -O3 -std=c++11 -Wall 
+CFLAGS   = -O3 -Wall
 
 .PHONY = clean test
 
 .DELETE_ON_ERROR:
 
-testingmlp: testingmlp.o generated.o
+testingmlp: testingmlp.o generated.o page-info.o
 	$(CXX) $(CXXFLAGS) -o $@ $^
-
 
 ifneq ($(GENERATE), 0)
 generated.cpp : gen.py
@@ -14,7 +14,14 @@ generated.cpp : gen.py
 endif
 
 %.o : %.cpp
-	$(CXX) $(CXXFLAGS) -c $^
+	$(CXX) $(CXXFLAGS) -c $<
+
+%.o : %.c
+	$(CC) $(CFLAGS) -c $<
+
+page-info.o : page-info.h
+
+generated.o testingmlp.o : common.hpp
 
 test: testingmlp
 	./testingmlp

--- a/consoleversion/Makefile
+++ b/consoleversion/Makefile
@@ -1,20 +1,27 @@
 CXXFLAGS = -O3 -std=c++11 -Wall -g
+CFLAGS   = -O3 -Wall
 
 .PHONY = clean test
 
 .DELETE_ON_ERROR:
 
-testingmlp: testingmlp.o generated.o
+testingmlp: testingmlp.o generated.o page-info.o
 	$(CXX) $(CXXFLAGS) -o $@ $^
-
 
 ifneq ($(GENERATE), 0)
 generated.cpp : gen.py
 	python3 gen.py > generated.cpp
 endif
 
-%.o : %.cpp common.hpp
+%.o : %.cpp
 	$(CXX) $(CXXFLAGS) -c $<
+
+%.o : %.c
+	$(CC) $(CFLAGS) -c $<
+
+page-info.o : page-info.h
+
+generated.o testingmlp.o : common.hpp
 
 test: testingmlp
 	./testingmlp

--- a/consoleversion/common.hpp
+++ b/consoleversion/common.hpp
@@ -1,3 +1,7 @@
+#ifndef MLP_COMMON_H_
+#define MLP_COMMON_H_
+
+#include <assert.h>
 #include <inttypes.h>
 #include <stdlib.h>
 #include <iostream>
@@ -9,11 +13,16 @@
 /* max MLP value tested with the naked strategy */
 constexpr int NAKED_MAX = 100;
 
-/* if true, try the pure pointer chasing strategy */
-constexpr int DO_NAKED = true;
-
 void naked_measure_body(float (&time_measure)[NAKED_MAX], uint64_t *bigarray, size_t howmanyhits, size_t repeat);
 
-typedef uint64_t (access_method_f)(uint64_t *bigarray, size_t howmanyhits);
+typedef uint64_t (access_method_f)(const uint64_t* sp, const uint64_t *bigarray, size_t howmanyhits);
 
-float time_one(uint64_t *bigarray, size_t howmanyhits, size_t repeat, access_method_f *method, size_t lanes, float firsttime, float lasttime);
+/** get the method implementing mlp_count access chains, up to NAKED_MAX */
+extern access_method_f * all_methods[];
+
+static inline access_method_f * get_method(size_t mlp) {
+    assert(mlp >= 1 && mlp < NAKED_MAX);
+    return all_methods[mlp - 1];
+}
+
+#endif

--- a/consoleversion/common.hpp
+++ b/consoleversion/common.hpp
@@ -12,8 +12,15 @@ constexpr int NAKED_MAX = 100;
 /* if true, try the pure pointer chasing strategy */
 constexpr int DO_NAKED = true;
 
-void naked_measure_body(float (&time_measure)[NAKED_MAX], uint64_t *bigarray, size_t howmanyhits, size_t repeat);
+#define ELEM_SIZE 64
 
-typedef uint64_t (access_method_f)(uint64_t *bigarray, size_t howmanyhits);
+struct Line {
+  uint64_t idx;
+  char filler[ELEM_SIZE - sizeof(Line*)];
+};
 
-float time_one(uint64_t *bigarray, size_t howmanyhits, size_t repeat, access_method_f *method, size_t lanes, float firsttime, float lasttime);
+void naked_measure_body(float (&time_measure)[NAKED_MAX], Line *bigarray, size_t howmanyhits, size_t repeat);
+
+typedef uint64_t (access_method_f)(Line *bigarray, size_t howmanyhits);
+
+float time_one(Line *bigarray, size_t howmanyhits, size_t repeat, access_method_f *method, size_t lanes, float firsttime, float lasttime);

--- a/consoleversion/gen.py
+++ b/consoleversion/gen.py
@@ -3,24 +3,18 @@
 print("#include \"common.hpp\"\n#include \"math.h\"\n")
 
 for i in range(1,100):
-    print("uint64_t naked_access_%d(uint64_t *bigarray, size_t howmanyhits) {"%(i))
-    for j in range(1,i+1):
-        print("  uint64_t val%d = %d;" %(j,j))
+    print("uint64_t naked_access_%d(const uint64_t *sp, const uint64_t *bigarray, size_t howmanyhits) {"%(i))
+    for j in range(i):
+        print("  uint64_t val%d = sp[%d];" %(j,j))
     print ("  size_t howmanyhits_perlane = howmanyhits / %d;"%(i))
     print("  for (size_t counter = 0; counter < howmanyhits_perlane; counter++) {")
-    for j in range(1,i+1):
+    for j in range(i):
         print("    val%d = bigarray[val%d];" %(j,j))
     print("  }")
-    ret = "  val1 "
-    for  j in range(2,i+1):
-      ret += "+ val%d " %(j)
-    print("  return ", ret,";")
+    print("  return ", "+".join("val%d"%j for j in range(i)), ";")
     print("}")
 
-
-print("void naked_measure_body(float (&time_measure)[NAKED_MAX], uint64_t *bigarray, size_t howmanyhits, size_t repeat) {")
-for i in range(1, 100):
-    first = "0.0" if i == 1 else "time_measure[1]"
-    last  = "0.0" if i == 1 else "time_measure[%d]"%(i-1)
-    print("  time_measure[%d] = time_one(bigarray, howmanyhits, repeat, naked_access_%d, %d, %s, %s);"%(i,i,i,first,last))
-print("}")
+# make the method array
+print('access_method_f * all_methods[] = {')
+print(',\n'.join("\tnaked_access_%d"%i for i in range(1,100)))
+print('\n};')

--- a/consoleversion/gen.py
+++ b/consoleversion/gen.py
@@ -3,22 +3,22 @@
 print("#include \"common.hpp\"\n#include \"math.h\"\n")
 
 for i in range(1,100):
-    print("uint64_t naked_access_%d(uint64_t *bigarray, size_t howmanyhits) {"%(i))
+    print("uint64_t naked_access_%d(Line *bigarray, size_t howmanyhits) {"%(i))
     for j in range(1,i+1):
         print("  uint64_t val%d = %d;" %(j,j))
     print ("  size_t howmanyhits_perlane = howmanyhits / %d;"%(i))
     print("  for (size_t counter = 0; counter < howmanyhits_perlane; counter++) {")
     for j in range(1,i+1):
-        print("    val%d = bigarray[val%d];" %(j,j))
+        print("    val%d = bigarray[val%d].idx;" %(j,j))
     print("  }")
     ret = "  val1 "
     for  j in range(2,i+1):
       ret += "+ val%d " %(j)
     print("  return ", ret,";")
-    print("}")
+    print("}\n")
 
 
-print("void naked_measure_body(float (&time_measure)[NAKED_MAX], uint64_t *bigarray, size_t howmanyhits, size_t repeat) {")
+print("void naked_measure_body(float (&time_measure)[NAKED_MAX], Line *bigarray, size_t howmanyhits, size_t repeat) {")
 for i in range(1, 100):
     first = "0.0" if i == 1 else "time_measure[1]"
     last  = "0.0" if i == 1 else "time_measure[%d]"%(i-1)

--- a/consoleversion/page-info.c
+++ b/consoleversion/page-info.c
@@ -1,0 +1,297 @@
+/*
+ * smaps.c
+ *
+ *  Created on: Jan 31, 2017
+ *      Author: tdowns
+ */
+
+#include "page-info.h"
+
+#include <stdio.h>
+#include <sys/types.h>
+#include <linux/kernel-page-flags.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <err.h>
+#include <assert.h>
+
+
+#define PM_PFRAME_MASK         ((1ULL << 55) - 1)
+#define PM_SOFT_DIRTY           (1ULL << 55)
+#define PM_MMAP_EXCLUSIVE       (1ULL << 56)
+#define PM_FILE                 (1ULL << 61)
+#define PM_SWAP                 (1ULL << 62)
+#define PM_PRESENT              (1ULL << 63)
+
+
+/** bundles a flag with its description */
+typedef struct {
+    int flag_num;
+    char const *name;
+    bool show_default;
+} flag;
+
+#define FLAG_SHOW(name) { KPF_ ## name, # name, true },
+#define FLAG_HIDE(name) { KPF_ ## name, # name, false },
+
+const flag kpageflag_defs[] = {
+        FLAG_SHOW(LOCKED       )
+        FLAG_HIDE(ERROR        )
+        FLAG_HIDE(REFERENCED   )
+        FLAG_HIDE(UPTODATE     )
+        FLAG_HIDE(DIRTY        )
+        FLAG_HIDE(LRU          )
+        FLAG_SHOW(ACTIVE       )
+        FLAG_SHOW(SLAB         )
+        FLAG_HIDE(WRITEBACK    )
+        FLAG_HIDE(RECLAIM      )
+        FLAG_SHOW(BUDDY        )
+        FLAG_SHOW(MMAP         )
+        FLAG_SHOW(ANON         )
+        FLAG_SHOW(SWAPCACHE    )
+        FLAG_SHOW(SWAPBACKED   )
+        FLAG_SHOW(COMPOUND_HEAD)
+        FLAG_SHOW(COMPOUND_TAIL)
+        FLAG_SHOW(HUGE         )
+        FLAG_SHOW(UNEVICTABLE  )
+        FLAG_SHOW(HWPOISON     )
+        FLAG_SHOW(NOPAGE       )
+        FLAG_SHOW(KSM          )
+        FLAG_SHOW(THP          )
+        FLAG_SHOW(BALLOON      )
+        FLAG_SHOW(ZERO_PAGE    )
+        FLAG_SHOW(IDLE         )
+
+        { -1, 0, false }  // sentinel
+};
+
+#define kpageflag_count (sizeof(kpageflag_defs)/sizeof(kpageflag_defs[0]) - 1)
+
+#define ITERATE_FLAGS for (flag const *f = kpageflag_defs; f->flag_num != -1; f++)
+
+
+// x-macro for doing some operation on all the pagemap flags
+#define PAGEMAP_X(fn) \
+    fn(softdirty ) \
+    fn(exclusive ) \
+    fn(file      ) \
+    fn(swapped   ) \
+    fn(present   )
+
+
+/* round the given pointer down to the page boundary (i.e,. return a pointer to the page it lives in) */
+static inline void *pagedown(void *p, unsigned psize) {
+    return (void *)(((uintptr_t)p) & -(uintptr_t)psize);
+}
+
+/**
+ * Extract the interesting info from a 64-bit pagemap value, and return it as a page_info.
+ */
+page_info extract_info(uint64_t bits) {
+    page_info ret = {};
+    ret.pfn         = bits & PM_PFRAME_MASK;
+    ret.softdirty   = bits & PM_SOFT_DIRTY;
+    ret.exclusive   = bits & PM_MMAP_EXCLUSIVE;
+    ret.file        = bits & PM_FILE;
+    ret.swapped     = bits & PM_SWAP;
+    ret.present     = bits & PM_PRESENT;
+    return ret;
+}
+
+/* print page_info to the given file */
+void fprint_info(FILE* f, page_info info) {
+    fprintf(f,
+            "PFN: %p\n"
+            "softdirty = %d\n"
+            "exclusive = %d\n"
+            "file      = %d\n"
+            "swapped   = %d\n"
+            "present   = %d\n",
+            (void*)info.pfn,
+            info.softdirty,
+            info.exclusive,
+            info.file,
+            info.swapped,
+            info.present);
+}
+
+void print_info(page_info info) {
+    fprint_info(stdout, info);
+}
+
+flag_count get_flag_count(page_info_array infos, int flag_num) {
+    flag_count ret = {};
+
+    if (flag_num < 0 || flag_num > 63) {
+        return ret;
+    }
+
+    uint64_t flag = (1ULL << flag_num);
+
+    ret.flag = flag_num;
+    ret.pages_total = infos.num_pages;
+
+    for (size_t i = 0; i < infos.num_pages; i++) {
+        page_info info = infos.info[i];
+        if (info.kpageflags_ok) {
+            ret.pages_set += (info.kpageflags & flag) == flag;
+            ret.pages_available++;
+        }
+    }
+    return ret;
+}
+
+/**
+ * Print the table header that lines up with the tabluar format used by the "table" printing
+ * functions. Called by fprint_ratios, or you can call it yourself if you want to prefix the
+ * output with your own columns.
+ */
+void fprint_info_header(FILE *file) {
+    fprintf(file,  "         PFN  sdirty   excl   file swappd presnt ");
+    ITERATE_FLAGS { if (f->show_default) fprintf(file, "%4.4s ", f->name); }
+    fprintf(file, "\n");
+}
+
+/* print one info in a tabular format (as a single row) */
+void fprint_info_row(FILE *file, page_info info) {
+    fprintf(file, "%12p %7d%7d%7d%7d%7d ",
+            (void*)info.pfn,
+            info.softdirty,
+            info.exclusive,
+            info.file,
+            info.swapped,
+            info.present);
+
+    if (info.kpageflags_ok) {
+        ITERATE_FLAGS { if (f->show_default) fprintf(file, "%4d ", !!(info.kpageflags & (1ULL << f->flag_num))); }
+    }
+    fprintf(file, "\n");
+}
+
+#define DECLARE_ACCUM(name) size_t name ## _accum = 0;
+#define INCR_ACCUM(name)    name ## _accum += info->name;
+#define PRINT_ACCUM(name)   fprintf(file, "%7.4f", (double)name ## _accum / infos.num_pages);
+
+
+void fprint_ratios_noheader(FILE *file, page_info_array infos) {
+    PAGEMAP_X(DECLARE_ACCUM);
+    size_t total_kpage_ok = 0;
+    size_t flag_totals[kpageflag_count] = {};
+    for (size_t p = 0; p < infos.num_pages; p++) {
+        page_info *info = &infos.info[p];
+        PAGEMAP_X(INCR_ACCUM);
+        if (info->kpageflags_ok) {
+            total_kpage_ok++;
+            int i = 0;
+            ITERATE_FLAGS {
+                flag_totals[i++] += !!(info->kpageflags & (1ULL << f->flag_num));
+            }
+        }
+    }
+
+    printf("%12s ", "----------");
+    PAGEMAP_X(PRINT_ACCUM)
+
+    int i = 0;
+    if (total_kpage_ok > 0) {
+        ITERATE_FLAGS {
+            if (f->show_default) fprintf(file, " %4.2f", (double)flag_totals[i] / total_kpage_ok);
+            i++;
+        }
+    }
+    fprintf(file, "\n");
+}
+
+/*
+ * Print a table with one row per page from the given infos.
+ */
+void fprint_ratios(FILE *file, page_info_array infos) {
+    fprint_info_header(file);
+    fprint_ratios_noheader(file, infos);
+}
+
+/*
+ * Prints a summary of all the pages in the given array as ratios: the fraction of the time the given
+ * flag was set.
+ */
+void fprint_table(FILE *f, page_info_array infos) {
+    fprintf(f, "%zu total pages\n", infos.num_pages);
+    fprint_info_header(f);
+    for (size_t p = 0; p < infos.num_pages; p++) {
+        fprint_info_row(f, infos.info[p]);
+    }
+}
+
+
+
+/**
+ * Get info for a single page indicated by the given pointer (which may point anywhere in the page)
+ */
+page_info get_page_info(void *p) {
+    int psize = getpagesize();
+    FILE *pagemap_file = fopen("/proc/self/pagemap", "rb");
+    if (!pagemap_file) err(EXIT_FAILURE, "failed to open pagemap");
+
+    if (fseek(pagemap_file, (uintptr_t)p / psize * sizeof(uint64_t), SEEK_SET)) err(EXIT_FAILURE, "pagemap seek failed");
+
+    uint64_t bits;
+    int readc;
+    if ((readc = fread(&bits, sizeof(bits), 1, pagemap_file)) != 1) err(EXIT_FAILURE, "unexpected fread return: %d", readc);
+
+    page_info info = extract_info(bits);
+
+    if (info.pfn) {
+        // we got a pfn, try to read /proc/kpageflags
+        FILE *kpageflags_file = fopen("/proc/kpageflags", "rb");
+        if (!kpageflags_file) {
+            warn("failed to open kpageflags");
+        } else {
+            if (fseek(kpageflags_file, info.pfn * sizeof(bits), SEEK_SET)) err(EXIT_FAILURE, "kpageflags seek failed");
+            if ((readc = fread(&bits, sizeof(bits), 1, kpageflags_file)) != 1) err(EXIT_FAILURE, "unexpected fread return: %d", readc);
+            info.kpageflags_ok = true;
+            info.kpageflags = bits;
+            fclose(kpageflags_file);
+        }
+    }
+
+    fclose(pagemap_file);
+
+    return info;
+}
+
+/**
+ * Get information for each page in the range from start (inclusive) to end (exclusive).
+ */
+page_info_array get_info_for_range(void *start, void *end) {
+    unsigned psize = getpagesize();
+    void *start_page = pagedown(start, psize);
+    void *end_page   = pagedown(end - 1, psize) + psize;
+    size_t page_count = start < end ? (end_page - start_page) / psize : 0;
+    assert(page_count == 0 || start_page < end_page);
+
+    page_info *infos = malloc((page_count + 1) * sizeof(page_info));
+
+    for (size_t p = 0; p < page_count; p++) {
+        infos[p] = get_page_info((char *)start + p * psize);
+    }
+
+    return (page_info_array){ page_count, infos };
+}
+
+void free_info_array(page_info_array infos) {
+    free(infos.info);
+}
+
+int flag_from_name(char const *name) {
+    ITERATE_FLAGS {
+        if (strcasecmp(f->name, name) == 0) {
+            return f->flag_num;
+        }
+    }
+    return -1;
+}
+
+

--- a/consoleversion/page-info.c
+++ b/consoleversion/page-info.c
@@ -12,11 +12,13 @@
 #include <linux/kernel-page-flags.h>
 #include <unistd.h>
 #include <string.h>
+#include <strings.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <err.h>
 #include <assert.h>
+#include <limits.h>
 
 
 #define PM_PFRAME_MASK         ((1ULL << 55) - 1)
@@ -61,9 +63,16 @@ const flag kpageflag_defs[] = {
         FLAG_SHOW(NOPAGE       )
         FLAG_SHOW(KSM          )
         FLAG_SHOW(THP          )
+        /* older kernels won't have these new flags, so conditionally compile in support for them */
+#ifdef KPF_BALLOON
         FLAG_SHOW(BALLOON      )
+#endif
+#ifdef KPF_ZERO_PAGE
         FLAG_SHOW(ZERO_PAGE    )
+#endif
+#ifdef KPF_IDLE
         FLAG_SHOW(IDLE         )
+#endif
 
         { -1, 0, false }  // sentinel
 };
@@ -81,6 +90,11 @@ const flag kpageflag_defs[] = {
     fn(swapped   ) \
     fn(present   )
 
+static unsigned get_page_size() {
+    long psize = sysconf(_SC_PAGESIZE);
+    assert(psize >= 1 && psize <= UINT_MAX);
+    return (unsigned)psize;
+}
 
 /* round the given pointer down to the page boundary (i.e,. return a pointer to the page it lives in) */
 static inline void *pagedown(void *p, unsigned psize) {
@@ -231,52 +245,81 @@ void fprint_table(FILE *f, page_info_array infos) {
  * Get info for a single page indicated by the given pointer (which may point anywhere in the page)
  */
 page_info get_page_info(void *p) {
-    int psize = getpagesize();
-    FILE *pagemap_file = fopen("/proc/self/pagemap", "rb");
-    if (!pagemap_file) err(EXIT_FAILURE, "failed to open pagemap");
-
-    if (fseek(pagemap_file, (uintptr_t)p / psize * sizeof(uint64_t), SEEK_SET)) err(EXIT_FAILURE, "pagemap seek failed");
-
-    uint64_t bits;
-    int readc;
-    if ((readc = fread(&bits, sizeof(bits), 1, pagemap_file)) != 1) err(EXIT_FAILURE, "unexpected fread return: %d", readc);
-
-    page_info info = extract_info(bits);
-
-    if (info.pfn) {
-        // we got a pfn, try to read /proc/kpageflags
-        FILE *kpageflags_file = fopen("/proc/kpageflags", "rb");
-        if (!kpageflags_file) {
-            warn("failed to open kpageflags");
-        } else {
-            if (fseek(kpageflags_file, info.pfn * sizeof(bits), SEEK_SET)) err(EXIT_FAILURE, "kpageflags seek failed");
-            if ((readc = fread(&bits, sizeof(bits), 1, kpageflags_file)) != 1) err(EXIT_FAILURE, "unexpected fread return: %d", readc);
-            info.kpageflags_ok = true;
-            info.kpageflags = bits;
-            fclose(kpageflags_file);
-        }
-    }
-
-    fclose(pagemap_file);
-
-    return info;
+    // just get the info array for a single page
+    page_info_array onepage = get_info_for_range(p, (char *)p + 1);
+    assert(onepage.num_pages == 1);
+    page_info ret = onepage.info[0];
+    free_info_array(onepage);
+    return ret;
 }
 
 /**
  * Get information for each page in the range from start (inclusive) to end (exclusive).
  */
 page_info_array get_info_for_range(void *start, void *end) {
-    unsigned psize = getpagesize();
+    unsigned psize = get_page_size();
     void *start_page = pagedown(start, psize);
     void *end_page   = pagedown(end - 1, psize) + psize;
     size_t page_count = start < end ? (end_page - start_page) / psize : 0;
     assert(page_count == 0 || start_page < end_page);
 
+    if (page_count == 0) {
+        return (page_info_array){ 0, NULL };
+    }
+
     page_info *infos = malloc((page_count + 1) * sizeof(page_info));
 
-    for (size_t p = 0; p < page_count; p++) {
-        infos[p] = get_page_info((char *)start + p * psize);
+    // open the pagemap file
+    FILE *pagemap_file = fopen("/proc/self/pagemap", "rb");
+    if (!pagemap_file) err(EXIT_FAILURE, "failed to open pagemap");
+
+    // seek to the first page
+    if (fseek(pagemap_file, (uintptr_t)start_page / psize * sizeof(uint64_t), SEEK_SET)) err(EXIT_FAILURE, "pagemap seek failed");
+
+    size_t bitmap_bytes = page_count * sizeof(uint64_t);
+    uint64_t* bitmap = malloc(bitmap_bytes);
+    assert(bitmap);
+    size_t readc = fread(bitmap, bitmap_bytes, 1, pagemap_file);
+    if (readc != 1) err(EXIT_FAILURE, "unexpected fread(pagemap) return: %zu", readc);
+
+    fclose(pagemap_file);
+
+    FILE *kpageflags_file = NULL;
+    enum { INIT, OPEN, FAILED  } file_state = INIT;
+
+    for (size_t page_idx = 0; page_idx < page_count; page_idx++) {
+        page_info info = extract_info(bitmap[page_idx]);
+
+        if (info.pfn) {
+            // we got a pfn, try to read /proc/kpageflags
+
+            // open file if not open
+            if (file_state == INIT) {
+                kpageflags_file = fopen("/proc/kpageflags", "rb");
+                if (!kpageflags_file) {
+                    warn("failed to open kpageflags");
+                    file_state = FAILED;
+                } else {
+                    file_state = OPEN;
+                }
+            }
+
+            if (file_state == OPEN) {
+                uint64_t bits;
+                if (fseek(kpageflags_file, info.pfn * sizeof(bits), SEEK_SET)) err(EXIT_FAILURE, "kpageflags seek failed");
+                if ((readc = fread(&bits, sizeof(bits), 1, kpageflags_file)) != 1) err(EXIT_FAILURE, "unexpected fread(kpageflags) return: %zu", readc);
+                info.kpageflags_ok = true;
+                info.kpageflags = bits;
+            }
+        }
+
+        infos[page_idx] = info;
     }
+
+    if (kpageflags_file)
+        fclose(kpageflags_file);
+
+    free(bitmap);
 
     return (page_info_array){ page_count, infos };
 }

--- a/consoleversion/page-info.h
+++ b/consoleversion/page-info.h
@@ -37,7 +37,7 @@ typedef struct {
  * Information for a number of virtually consecutive pages.
  */
 typedef struct {
-    /* how many pages_info are structures are in the array pointed to by info */
+    /* how many page_info structures are in the array pointed to by info */
     size_t num_pages;
 
     /* pointer to the array of page_info structures */

--- a/consoleversion/page-info.h
+++ b/consoleversion/page-info.h
@@ -1,0 +1,152 @@
+/*
+ * page-info.h
+ */
+
+#ifndef PAGE_INFO_H_
+#define PAGE_INFO_H_
+
+#include <stddef.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    /* page frame number: if present, the physical frame for the page */
+    uint64_t pfn;
+    /* soft-dirty set */
+    bool softdirty;
+    /* exclusively mapped, see e.g., https://patchwork.kernel.org/patch/6787921/ */
+    bool exclusive;
+    /* is a file mapping */
+    bool file;
+    /* page is swapped out */
+    bool swapped;
+    /* page is present, i.e, a physical page is allocated */
+    bool present;
+    /* if true, the kpageflags were successfully loaded, if false they were not (and are all zero) */
+    bool kpageflags_ok;
+    /* the 64-bit flag value extracted from /proc/kpageflags only if pfn is non-null */
+    uint64_t kpageflags;
+
+} page_info;
+/*
+ * Information for a number of virtually consecutive pages.
+ */
+typedef struct {
+    /* how many pages_info are structures are in the array pointed to by info */
+    size_t num_pages;
+
+    /* pointer to the array of page_info structures */
+    page_info *info;
+} page_info_array;
+
+
+typedef struct {
+    /* the number of pages on which this flag was set, always <= pages_available */
+    size_t pages_set;
+
+    /* the number of pages on which information could be obtained */
+    size_t pages_available;
+
+    /* the total number of pages examined, which may be greater than pages_available if
+     * the flag value could not be obtained for some pages (usually because the pfn is not available
+     * since the page is not yet present or because running as non-root.
+     */
+    size_t pages_total;
+
+    /* the flag the values were queried for */
+    int flag;
+
+} flag_count;
+
+/**
+ * Examine the page info in infos to count the number of times a specified /proc/kpageflags flag was set,
+ * effectively giving you a ratio, so you can say "80% of the pages for this allocation are backed by
+ * huge pages" or whatever.
+ *
+ * The flags *must* come from kpageflags (these are not the same as those in /proc/pid/pagemap) and
+ * are declared in linux/kernel-page-flags.h.
+ *
+ * Ideally, the flag information is available for all the pages in the range, so you can
+ * say something about the entire range, but this is often not the case because (a) flags
+ * are not available for pages that aren't present and (b) flags are generally never available
+ * for non-root users. So the ratio structure indicates both the total number of pages as
+ * well as the number of pages for which the flag information was available.
+ */
+flag_count get_flag_count(page_info_array infos, int flag);
+
+/**
+ * Given the case-insensitive name of a flag, return the flag number (the index of the bit
+ * representing this flag), or -1 if the flag is not found. The "names" of the flags are
+ * the same as the macro names in <linux/kernel-page-flags.h> without the KPF_ prefix.
+ *
+ * For example, the name of the transparent hugepages flag is "THP" and the corresponding
+ * macro is KPF_THP, and the value of this macro and returned by this method is 22.
+ *
+ * You can generate the corresponding mask value to check the flag using (1ULL << value).
+ */
+int flag_from_name(char const *name);
+
+/**
+ * Print the info in the page_info structure to stdout.
+ */
+void print_info(page_info info);
+
+/**
+ * Print the info in the page_info structure to the give file.
+ */
+void fprint_info(FILE* file, page_info info);
+
+
+/**
+ * Print the table header that lines up with the tabluar format used by the "table" printing
+ * functions. Called by fprint_ratios, or you can call it yourself if you want to prefix the
+ * output with your own columns.
+ */
+void fprint_info_header(FILE *file);
+
+/* print one info in a tabular format (as a single row) */
+void fprint_info_row(FILE *file, page_info info);
+
+
+/**
+ * Print the ratio for each flag in infos. The ratio is the number of times the flag was set over
+ * the total number of pages (or the total number of pages for which the information could be obtained).
+ */
+void fprint_ratios_noheader(FILE *file, page_info_array infos);
+/*
+ * Print a table with one row per page from the given infos.
+ */
+void fprint_ratios(FILE *file, page_info_array infos);
+
+/*
+ * Prints a summary of all the pages in the given array as ratios: the fraction of the time the given
+ * flag was set.
+ */
+void fprint_table(FILE *f, page_info_array infos);
+
+
+/**
+ * Get info for a single page indicated by the given pointer (which may point anywhere in the page).
+ */
+page_info get_page_info(void *p);
+
+/**
+ * Get information for each page in the range from start (inclusive) to end (exclusive).
+ */
+page_info_array get_info_for_range(void *start, void *end);
+
+/**
+ * Free the memory associated with the given page_info_array. You shouldn't use it after this call.
+ */
+void free_info_array(page_info_array infos);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PAGE_INFO_H_ */

--- a/consoleversion/plot-csv.py
+++ b/consoleversion/plot-csv.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+
+import matplotlib.pyplot as mpl
+import matplotlib.pyplot as plt
+import matplotlib.ticker as plticker
+import pandas as pd
+import numpy as np
+import csv
+import argparse
+import sys
+import collections
+import os
+import json
+
+# for arguments that should be comma-separate lists, we use splitlsit as the type
+splitlist = lambda x: x.split(',')
+
+p = argparse.ArgumentParser(usage='plot output from PLOT=1 ./bench')
+
+# input and output file configuration
+p.add_argument('input', help='CSV file to plot (or stdin)', nargs='*',
+    type=argparse.FileType('r'), default=[ sys.stdin ])
+p.add_argument('--out', help='output filename')
+
+# input parsing configuration
+p.add_argument('--sep', help='separator character (or regex) for input', default=',')
+
+# column selection and configuration
+p.add_argument('--xcol', help='Column index to use as x axis (default: 0)', type=int, default=0)
+p.add_argument('--cols-by-name', help='Use only these comma-separated columns, specified by "name", i.e., the column header (default: all columns)',
+    type=splitlist)
+p.add_argument('--allxticks', help="Force one x-axis tick for each value, disables auto ticks and may crowd x-axis", action='store_true')
+p.add_argument('--cols',  help='Use only these zero-based columns on primary axis (default: all columns)',
+    type=int, nargs='+')
+p.add_argument('--cols2', help='Use only these zero-based columns on secondary axis (default: no secondary axis)',
+    type=int, nargs='+')
+p.add_argument('--color-map', help='A JSON map from column name to color to use for that column',
+    type=json.loads)
+
+# chart labels and text
+p.add_argument('--clabels', help="Comma separated list of column names used as label for data series (default: column header)",
+    type=splitlist)
+p.add_argument('--scatter', help='Do an XY scatter plot (default is a line splot with x values used only as labels)', action='store_true')
+p.add_argument('--title', help='Set chart title', default='Some chart (use --title to specify title)')
+p.add_argument('--xlabel', help='Set x axis label')
+p.add_argument('--ylabel', help='Set y axis label')
+p.add_argument('--suffix-names', help='Suffix each column name with the file it came from', action='store_true')
+
+# data manipulation
+p.add_argument('--jitter', help='Apply horizontal (x-axis) jitter of the given relative amount (default 0.1)',
+    nargs='?', type=float, const=0.1)
+p.add_argument('--group', help='Group data by the first column, with new min/median/max columns with one row per group')
+
+# axis and line/point configuration
+p.add_argument('--ylim', help='Set the y axis limits explicitly (e.g., to cross at zero)', type=float, nargs='+')
+p.add_argument('--xrotate', help='rotate the xlablels by this amount', default=0)
+p.add_argument('--tick-interval', help='use the given x-axis tick spacing (in x axis units)', type=int)
+p.add_argument('--marker', help='use the given marker', type=str)
+p.add_argument('--markersize', help='use the given marker', type=float)
+p.add_argument('--linewidth', help='use the given line width', type=float)
+p.add_argument('--tight', help='use tight_layout for less space around chart', action='store_true')
+
+
+# debugging
+p.add_argument('--verbose', '-v', help='enable verbose logging', action='store_true')
+args = p.parse_args()
+
+vprint = print if args.verbose else lambda *a: None
+vprint("args = ", args)
+
+# fix various random seeds so we get reproducible plots
+# fix the mpl seed used to generate SVG IDs
+mpl.rcParams['svg.hashsalt'] = 'foobar'
+
+# numpy random seeds (used by e.g., jitter function below)
+np.random.seed(123)
+
+# if we are reading from stdin and stdin is a tty, print a warning since maybe the user just messed up
+# the arguments and otherwise we just appear to hang
+if (args.input and args.input[0] == sys.stdin):
+    print("reading from standard input...", file=sys.stderr)
+
+xi = args.xcol
+dfs = []
+for f in args.input:
+    df = pd.read_csv(f, sep=args.sep)
+    if args.suffix_names:
+        df = df.add_suffix(' ' + os.path.basename(f.name))
+    vprint("----- df from: ", f.name, "-----\n", df.head(), "\n---------------------")
+    dfs.append(df)
+
+df = pd.concat(dfs, axis=1)
+vprint("----- merged df -----\n", df.head(), "\n---------------------")
+
+# renames duplicate columns by suffixing _1, _2 etc
+class renamer():
+    def __init__(self):
+        self.d = dict()
+
+    def __call__(self, x):
+        if x not in self.d:
+            self.d[x] = 0
+            return x
+        else:
+            self.d[x] += 1
+            return "%s_%d" % (x, self.d[x])
+
+
+# rename any duplicate columns because otherwise Pandas gets mad
+df = df.rename(columns=renamer())
+
+vprint("---- renamed df ----\n", df.head(), "\n---------------------")
+
+def col_names_to_indices(requested, df):
+    vprint("requested columns: ", requested)
+    colnames = [x.strip() for x in df.columns.tolist()]
+    vprint("actual columns: ", colnames)
+    cols = []
+    for name in requested:
+        if not name in colnames:
+            exit("column name " + name + " not found, input columns were: " + ','.join(colnames))
+        cols.append(colnames.index(name))
+    return cols
+
+
+def extract_cols(cols, df, name):
+    vprint(name, "axis columns: ", cols)
+    if (not cols): return None
+    if (max(cols) >= len(df.columns)):
+        print("Column", max(cols), "too large: input only has", len(df.columns), "columns", file=sys.stderr)
+        exit(1)
+    # ensure xi is the first thing in the column list
+    if xi in cols: cols.remove(xi)
+    cols = [xi] + cols
+    vprint(name, " final columns: ", cols)
+    pruned = df.iloc[:, cols]
+    vprint("----- pruned ", name, " df -----\n", pruned.head(), "\n---------------------")
+    return pruned
+
+
+if args.cols_by_name:
+    cols = col_names_to_indices(args.cols_by_name, df)
+elif args.cols:
+    cols = args.cols
+else:
+    cols = list(range(len(df.columns)))
+
+df = extract_cols(cols, df, "primary")
+df2 = extract_cols(args.cols2, df, "secondary")
+
+if args.clabels:
+    if len(df.columns) != len(args.clabels):
+        sys.exit("ERROR: number of column labels " + str(len(args.clabels)) +
+                " not equal to the number of selected columns " + str(len(df.columns)))
+    df.columns = args.clabels
+
+# dupes will break pandas beyond this point, should be impossible due to above renaming
+dupes = df.columns.duplicated()
+if True in dupes:
+    print("Duplicate columns after merge and pruning, consider --suffix-names",
+        df.columns[dupes].values.tolist(), file=sys.stderr)
+    exit(1)
+
+# do grouping (feature not complete)
+if (args.group):
+    vprint("before grouping\n", df)
+
+    dfg = df.groupby(by=df.columns[0])
+
+    df = dfg.agg([min, pd.DataFrame.median, max])
+
+    vprint("agg\n---------------\n", df)
+
+    df.columns = [tup[0] + ' (' + tup[1] + ')' for tup in df.columns.values]
+    df.reset_index(inplace=True)
+
+    vprint("flat\n---------------\n", df)
+
+def jitter(arr, multiplier):
+    stdev = multiplier*(max(arr)-min(arr))/len(arr)
+    return arr if not len(arr) else arr + np.random.randn(len(arr)) * stdev
+
+if args.jitter:
+    df.iloc[:,xi] = jitter(df.iloc[:,xi], args.jitter)
+
+kwargs = {}
+
+if (args.linewidth):
+    kwargs["linewidth"] = args.linewidth
+
+if args.color_map:
+    colors = []
+    for i, cname in enumerate(df.columns):
+        if i == xi:
+            continue
+        if cname in args.color_map:
+            vprint("Using color {} for column {}".format(args.color_map[cname], cname))
+            colors.append(args.color_map[cname])
+        else:
+            print("WARNING no entry for column {} in given color-map".format(cname))
+    vprint("colors = ", colors)
+    kwargs["color"] = colors
+
+if (args.scatter):
+    kwargs['linestyle'] = 'none'
+    kwargs['marker'] = args.marker if args.marker else '.'
+elif (args.marker):
+    kwargs['marker'] = args.marker
+
+if (args.markersize):
+    kwargs['markersize'] = args.markersize
+
+# set x labels to strings so we don't get a scatter plot, and
+# so the x labels are not themselves plotted
+#if (args.scatter):
+#    ax = df.plot.line(x=0, title=args.title, figsize=(12,8), grid=True, **kwargs)
+#else:
+    # df.iloc[:,xi] = df.iloc[:,xi].apply(str)
+ax = df.plot.line(x=0, title=args.title, figsize=(12,8), grid=True, **kwargs)
+
+# this sets the ticks explicitly to one per x value, which means that
+# all x values will be shown, but the x-axis could be crowded if there
+# are too many
+if args.allxticks:
+    ticks = df.iloc[:,xi].values
+    plt.xticks(ticks=range(len(ticks)), labels=ticks)
+
+if (args.tick_interval):
+    ax.xaxis.set_major_locator(plticker.MultipleLocator(base=args.tick_interval))
+
+if (args.xrotate):
+    plt.xticks(rotation=args.xrotate)
+
+if args.ylabel:
+    ax.set_ylabel(args.ylabel)
+
+if args.xlabel:
+    ax.set_xlabel(args.xlabel)
+
+if args.ylim:
+    if (len(args.ylim) == 1):
+        ax.set_ylim(args.ylim[0])
+    elif (len(args.ylim) == 2):
+        ax.set_ylim(args.ylim[0], args.ylim[1])
+    else:
+        sys.exit('provide one or two args to --ylim')
+
+# secondary axis handling
+if df2 is not None:
+    df2.plot(x=0, secondary_y=True, ax=ax, grid=True)
+
+if (args.tight):
+    plt.tight_layout()
+
+if (args.out):
+    vprint("Saving figure to ", args.out, "...")
+    plt.savefig(args.out)
+else:
+    vprint("Showing interactive plot...")
+    plt.show()

--- a/consoleversion/plot-csv.py
+++ b/consoleversion/plot-csv.py
@@ -45,6 +45,7 @@ p.add_argument('--title', help='Set chart title', default='Some chart (use --tit
 p.add_argument('--xlabel', help='Set x axis label')
 p.add_argument('--ylabel', help='Set y axis label')
 p.add_argument('--suffix-names', help='Suffix each column name with the file it came from', action='store_true')
+p.add_argument('--no-legend', help='Do no display the legend', action='store_true')
 
 # data manipulation
 p.add_argument('--jitter', help='Apply horizontal (x-axis) jitter of the given relative amount (default 0.1)',
@@ -59,6 +60,8 @@ p.add_argument('--marker', help='use the given marker', type=str)
 p.add_argument('--markersize', help='use the given marker', type=float)
 p.add_argument('--linewidth', help='use the given line width', type=float)
 p.add_argument('--tight', help='use tight_layout for less space around chart', action='store_true')
+p.add_argument('--xscale', help='set the xscale value, e.g., --xscale log for logarithmic x axis', type=str)
+p.add_argument('--yscale', help='set the yscale value, e.g., --yscale log for logarithmic y axis', type=str)
 
 
 # debugging
@@ -236,6 +239,11 @@ if args.ylabel:
 
 if args.xlabel:
     ax.set_xlabel(args.xlabel)
+
+if (args.xscale): ax.set_xscale(args.xscale)
+if (args.yscale): ax.set_yscale(args.yscale)
+
+if (args.no_legend): ax.get_legend().remove()
 
 if args.ylim:
     if (len(args.ylim) == 1):

--- a/consoleversion/testingmlp.cpp
+++ b/consoleversion/testingmlp.cpp
@@ -243,8 +243,7 @@ void *malloc_aligned(size_t size, size_t alignment) {
 
 int main() {
   assert(do_csv >= 0 && do_csv <= 2);
-  printi("CLOCKS_PER_SEC: %zu\n", (size_t)CLOCKS_PER_SEC);
-  size_t max_mlp = getenv_int("MLP_MAX_MLP", 30);
+  size_t max_mlp = getenv_int("MLP_MAX_MLP", 40);
   printi("Initializing array made of %zu 64-bit words (%5.2f MiB).\n", len_end, len_end * 8. / 1024. / 1024.);
   uint64_t *array = (uint64_t *)malloc_aligned(sizeof(uint64_t) * len_end, 2 * 1024 * 1024);
   madvise(array, len_end * 8, MADV_HUGEPAGE);

--- a/consoleversion/testingmlp.cpp
+++ b/consoleversion/testingmlp.cpp
@@ -20,8 +20,8 @@ bool getenv_bool(const char *var) {
 }
 
 const int do_csv       = getenv_int("MLP_CSV", 0);
-const size_t len_start = getenv_int("MLP_START", 1) * 1024ull; // 1 KiB
-const size_t len_end   = getenv_int("MLP_STOP", 32 * 1024) * 1024ull; // 256 MiB
+const size_t len_start = getenv_int("MLP_START", 32 * 1024) * 1024ull; // 1 KiB
+const size_t len_end   = getenv_int("MLP_STOP",  32 * 1024) * 1024ull; // 256 MiB
 
 
 FILE* ifile = do_csv ? stderr : stdout;
@@ -124,7 +124,7 @@ void make_cycle(uint64_t* array, uint64_t* index, size_t length) {
     assert(cur < length);
   } while (cur != 0);
 
-  // printi("chain total: %zu\n", cycle_total(array));
+  if (!do_csv) printi("chain total: %zu\n", cycle_total(array));
   assert(total == length);
 }
 
@@ -150,7 +150,8 @@ void setup_pointers(uint64_t* sp, const uint64_t* array, const uint64_t* index, 
       mind = std::min(mind, dist);
       maxd = std::max(maxd, dist);
     }
-    printi("inter-chain dists: ideal=%zu, min=%zu, max=%zu\n", length / mlp, mind, maxd);
+    // printi("inter-chain dists: ideal=%zu, min=%zu, max=%zu\n", length / mlp, mind, maxd);
+    assert(mind >= length / mlp); // check that the min distance is as good as expected
   }
 }
 

--- a/consoleversion/testingmlp.cpp
+++ b/consoleversion/testingmlp.cpp
@@ -1,23 +1,52 @@
 #include "common.hpp"
 
+#include <assert.h>
+#include <string.h>
 #include <random>
+#include <chrono>
 
-float time_one(uint64_t *bigarray, size_t howmanyhits, size_t repeat, access_method_f *method, size_t lanes, float firsttime, float lasttime) {
-  clock_t begin_time, end_time;
+int getenv_int(const char *var, int def) {
+    const char *val = getenv(var);
+    return val ? atoi(val) : def;
+}
+
+bool getenv_bool(const char *var) {
+    const char *val = getenv(var);
+    return val && strcmp(val, "1") == 0;
+}
+
+const bool do_csv      = getenv_bool("MLP_CSV");
+const size_t len_start = getenv_int("MLP_START", 1) * 1024ull; // 1 KiB
+const size_t len_end   = getenv_int("MLP_START", 32 * 1024) * 1024ull; // 256 MiB
+
+
+FILE* ifile = do_csv ? stderr : stdout;
+
+#define printi(...) fprintf(ifile, __VA_ARGS__)
+
+float time_one(const uint64_t* sp,
+               const uint64_t *bigarray,
+               size_t howmanyhits,
+               size_t repeat,
+               access_method_f *method,
+               size_t lanes,
+               float firsttime,
+               float lasttime) {
+  using namespace std::chrono;
   float mintime = 99999999999;
   uint64_t bogus = 0;
   for (size_t r = 0; r < repeat; r++) {
-    begin_time = clock();
-    bogus += method(bigarray, howmanyhits);
-    end_time = clock();
-    float tv = float(end_time - begin_time) / CLOCKS_PER_SEC;
+    auto begin_time = high_resolution_clock::now();
+    bogus += method(sp, bigarray, howmanyhits);
+    auto end_time = high_resolution_clock::now();
+    float tv = duration<float>(end_time - begin_time).count();
     if (tv < mintime)
       mintime = tv;
   }
   if (bogus == 0x010101) {
     printf("ping!");
   }
-  // compute the bandwidth 
+  // compute the bandwidth
   size_t cachelineinbytes = 64;
   size_t rounded_hits = ( howmanyhits / lanes * lanes );
   size_t volume = rounded_hits * cachelineinbytes;
@@ -26,71 +55,89 @@ float time_one(uint64_t *bigarray, size_t howmanyhits, size_t repeat, access_met
   double expected = lasttime * (lanes - 1) / lanes;  // expected time if at max efficiency
   double efficiency = lanes == 1 ? 0 : 100.0 * (lasttime - mintime) / (lasttime - expected);
   double speedup = lanes == 1 ? 1 : firsttime / mintime;
-  printf("%12zu %12f %10.0f  %8.1f  %6.0f%%  %9.1f\n",
-    lanes, mintime, round(mbpers), nanoperquery, efficiency, speedup);
+  if (do_csv) {
+    printf("%zu,%f,%.0f,%.1f,%.0f%%,%.3f\n",
+      lanes, mintime, round(mbpers), nanoperquery, efficiency, speedup);
+  } else {
+    printf("%12zu %12f %10.0f  %8.1f  %6.0f%%  %9.1f\n",
+      lanes, mintime, round(mbpers), nanoperquery, efficiency, speedup);
+  }
   return mintime;
 }
 
-int naked_measure(size_t length) {
-  std::cout << "Initializing array made of " << length << " 64-bit words." << std::endl;
-  uint64_t *bigarray = (uint64_t *)malloc(sizeof(uint64_t) * length);
-  // create a cycle of maximum length within the bigarray
-  for (size_t i = 0; i < length; i++) {
-    bigarray[i] = i;
+/* advance starting at p, n times */
+size_t incr(const uint64_t* array, uint64_t p, size_t n) {
+  while (n--) {
+    p = array[p];
   }
-  std::cout << "Applying Sattolo's algorithm. " << std::endl;
+  return p;
+}
+
+size_t cycle_dist(const uint64_t* array, uint64_t from, uint64_t to) {
+  size_t dist = 0;
+  while (from != to) {
+    from = array[from];
+    dist++;
+  }
+  return dist;
+}
+
+size_t cycle_total(const uint64_t* array) {
+  auto first = array[0];
+  return 1 + cycle_dist(array, first, 0);
+}
+
+uint64_t *init_array(size_t length, size_t max_mlp) {
+  printi("Initializing array made of %zu 64-bit words (%5.2f MiB).\n", length, length * 8. / 1024. / 1024.);
+  uint64_t *bigarray = (uint64_t *)malloc(sizeof(uint64_t) * length);
+  return bigarray;
+}
+
+/** make a cycle of length starting at element 0 of the given array */
+void make_cycle(uint64_t* array, size_t length) {
+// create a cycle of maximum length within the bigarray
+  for (size_t i = 0; i < length; i++) {
+    array[i] = i;
+  }
+  printi("Applying Sattolo's algorithm... ");
+  fflush(ifile);
   // Sattolo
   std::mt19937_64 engine;
   engine.seed(0xBABE);
-  for (size_t i = NAKED_MAX + 1; i + 1 < length; i++) {
+  for (size_t i = 0; i + 1 < length; i++) {
     std::uniform_int_distribution<size_t> dist{i + 1, length - 1};
     size_t swapidx = dist(engine);
-    std::swap(bigarray[i], bigarray[swapidx]);
+    std::swap(array[i], array[swapidx]);
   }
-  std::cout << "Surgery on the long cycle. " << std::endl;
-  uint64_t current_start = 1;
-  uint64_t current_pointer = NAKED_MAX + 1;//  arbitrary
-  uint64_t a = bigarray[current_pointer];
-  uint64_t b = bigarray[a];
-  bigarray[a] = current_start;
-  bigarray[current_start] = b;
-  current_pointer = current_start;
-  current_start++;
-  size_t targetdist = (length - NAKED_MAX - 1 - 1) / NAKED_MAX;
-  size_t cdist = 0;
-  while(current_start <= NAKED_MAX) {
-    cdist = 0;
-    while(cdist < targetdist) {
-      current_pointer = bigarray[current_pointer];
-      cdist++;
-    }
-    a = current_pointer;
-    b = bigarray[a];
-    bigarray[a] = current_start;
-    bigarray[current_start] = b;
-    current_pointer = current_start;
-    current_start++;
+  printi("chain total: %zu\n", cycle_total(array));
+}
+
+int naked_measure(uint64_t* bigarray, size_t length, size_t max_mlp) {
+
+  make_cycle(bigarray, length);
+
+  printi("Surgery on the long cycle. \n");
+  uint64_t starting_pointers[NAKED_MAX] = {};
+  starting_pointers[0] = 0;
+  for (size_t sp = 1; sp < NAKED_MAX; sp++) {
+    starting_pointers[sp] = incr(bigarray, starting_pointers[sp - 1], length / NAKED_MAX);
   }
-  std::cout << "Verifying the neighboring distance... " << std::endl;
-  // next, we check how close the neighbors are
-  // 1, 2, ... 30
-  size_t mindist = length;
-  size_t currentdist = 0;
-  uint64_t target = 1;
-  do {
-    target = bigarray[target];
-    currentdist ++;
-    if((target > 0) && (target < NAKED_MAX)) {
-       if(mindist > currentdist) mindist = currentdist;
-       currentdist = 0;
-    }
-  } while (target != 1);
-  printf("mindist = %zu vs %zu \n", mindist, (size_t) (length/NAKED_MAX));
+
+  printi("Verifying the neighboring distance... \n");
+  size_t mind = -1, maxd = 0;
+  for (size_t i = 1; i < max_mlp; i++) {
+    uint64_t from = starting_pointers[i];
+    uint64_t to   = starting_pointers[i + 1];
+    size_t dist = cycle_dist(bigarray, from, to);
+    mind = std::min(mind, dist);
+    maxd = std::max(maxd, dist);
+  }
+  printi("inter-chain dists: ideal=%zu, min=%zu, max=%zu\n", length / max_mlp, mind, maxd);
   uint64_t sum1 = 0, sum2 = 0, sum3 = 0, sum4 = 0;
   clock_t begin_time, end_time;
   int sumrepeat = 10;
   float mintime = 99999999999;
-  while(sumrepeat-- >0) {
+  while (sumrepeat-- >0) {
     begin_time = clock();
     for(size_t i = 0; i < length - 3 * 8; i+= 32) {
       sum1 ^= bigarray[i];
@@ -104,26 +151,29 @@ int naked_measure(size_t length) {
       mintime = tv;
   }
   if((sum1 ^ sum2 ^ sum3 ^ sum4) == 0x1010) printf("bug");
-  printf("Time to sum up the array (linear scan) %.3f s (x 8 = %.3f s), bandwidth = %.1f MB/s \n",mintime,8*mintime, length * sizeof(uint64_t) / mintime / (1024.0 * 1024.0));
+  printi("Time to sum up the array (linear scan) %.3f s (x 8 = %.3f s), bandwidth = %.1f MB/s \n",mintime,8*mintime, length * sizeof(uint64_t) / mintime / (1024.0 * 1024.0));
 
-  float time_measure[NAKED_MAX];
+  float time_measure[NAKED_MAX] = {};
   size_t howmanyhits = length; //1 * 4 * 5 * 6 * 7 * 8 * 9 * 11 * 13 * 17;
   int repeat = 5;
-  printf("Legend:\n"
-  "  BandW: Implied bandwidth (assuming 64-byte cache line) in MB/s\n"
-  "  %% Eff: Effectiness of this lane count compared to the prior, as a %% of ideal\n"
-  "  Speedup: Speedup factor for this many lanes versus one lane\n"
-  );
-  printf("---------------------------------------------------------------------\n");
-  printf("- # of lanes --- time (s) ---- BandW -- ns/hit -- %% Eff -- Speedup --\n");
-  printf("---------------------------------------------------------------------\n");
-  naked_measure_body(time_measure, bigarray, howmanyhits, repeat);
+  if (do_csv) {
+    printf("lanes,time,bw,ns/hit,eff,speedup\n");
+  } else {
+    printi("Size: %zu (%5.2f KiB, %5.2f MiB)\n", length, length * 8. / 1024., length * 8. / 1024. / 1024.);
+    printi("---------------------------------------------------------------------\n");
+    printi("- # of lanes --- time (s) ---- BandW -- ns/hit -- %% Eff -- Speedup --\n");
+    printi("---------------------------------------------------------------------\n");
+  }
 
-  for (size_t i = 2; i < NAKED_MAX; i++) {
+  // naked_measure_body(time_measure, bigarray, howmanyhits, repeat);
+  for (size_t m = 1; m <= max_mlp; m++) {
+    time_measure[m] = time_one(starting_pointers, bigarray, howmanyhits, repeat, get_method(m), m, time_measure[1], time_measure[m - 1]);
+  }
+
+  for (size_t i = 2; !do_csv && i < NAKED_MAX; i++) {
     float ratio = (time_measure[i - 1] - time_measure[i]) / time_measure[i - 1];
 
-    if (ratio <
-        0.01) // if a new lane does not add at least 1% of performance...
+    if (ratio < 0.01) // if a new lane does not add at least 1% of performance...
     {
       std::cout << "Maybe you have about " << i - 1 << " parallel paths? "
                 << std::endl;
@@ -131,11 +181,24 @@ int naked_measure(size_t length) {
       break;
     }
   }
-  printf("--------------------------------------------------------------\n");
+  printi("--------------------------------------------------------------\n");
   return 10000;
 }
 
 int main() {
-  size_t length = 1 << 25;
-  naked_measure(length);
+  printi("CLOCKS_PER_SEC: %zu\n", (size_t)CLOCKS_PER_SEC);
+  size_t max_mlp = getenv_int("MLP_MAX_MLP", 30);
+  auto array = init_array(len_end, max_mlp);
+
+  if (!do_csv) {
+    printi("Legend:\n"
+        "  BandW: Implied bandwidth (assuming 64-byte cache line) in MB/s\n"
+        "  %% Eff: Effectiness of this lane count compared to the prior, as a %% of ideal\n"
+        "  Speedup: Speedup factor for this many lanes versus one lane\n"
+    );
+  }
+
+  for (size_t length = len_start; length <= len_end; length *= 2) {
+    naked_measure(array, length, max_mlp);
+  }
 }


### PR DESCRIPTION
The main thing this does is:

 - Allows you specify `MLP_CSV=1` or `MLP_CSV=2` env var to get csv output, easy for plotting
 - Iterates over a variety of sizes with a single invocation (see `MLP_START` an `MLP_STOP`), but defaults to just one (the same one as now).
 - Fixes a potentially serious bug: the way we spaces out the pointers (the surgery) used a gap of `length / NAKED_MAX`, for all MLP values. However, this gap is too small for any MLP value except for `NAKED_MAX` (100) and means that except fro MLP 1, all except for the leading pointer will run into the area accessed by the pointer ahead of it, so they will have advantageous caching behavior compared to the ideal of  accessing the area randomly, and hence will be advantaged versus the 1 MLP case. The impact is mostly near "interesting" boundaries like the size of a cache level, so probably not at the 256 MiB region we used by default.
 - Aligns the allocation and uses `madvise` to get huge pages. I'm not sure how we thought we were getting them before, even with "always" you usually don't get hugepages if your allocation isn't aligned. Now you'll get them.

These changes means this doesn't compile on Windows. I'm not sure if it it did before.